### PR TITLE
Исправить sudo для администрирования через SSH

### DIFF
--- a/app/src/main/java/com/wdtt/plus/ServerAdminClient.kt
+++ b/app/src/main/java/com/wdtt/plus/ServerAdminClient.kt
@@ -904,16 +904,17 @@ private class AdminSshClient(private val session: Session, private val sudoPassw
 
     fun execRootWithStdin(command: String, stdinPayload: String, timeout: Long): String {
         val isRoot = session.userName == "root"
-        if (!isRoot) {
-            exec("sudo -S -p '' -v", 20_000L, sudoPassword + "\n")
-        }
         val quoted = "'" + command.replace("'", "'\"'\"'") + "'"
         val rootCommand = if (isRoot) {
             "bash -c $quoted"
         } else {
-            "sudo -n bash -c $quoted"
+            "sudo -S -p '' bash -c $quoted"
         }
-        return exec(rootCommand, timeout, stdinPayload)
+        // sudo authentication timestamps are not shared between separate SSH exec channels
+        // on every server. Keep authentication and the stdin-based WDTT admin request in
+        // this one channel: sudo consumes the first line and wdtt-server receives the rest.
+        val payload = if (isRoot) stdinPayload else "$sudoPassword\n$stdinPayload"
+        return exec(rootCommand, timeout, payload)
     }
 
     fun exec(command: String, timeout: Long): String = exec(command, timeout, null)


### PR DESCRIPTION
## Проблема

При обновлении блока «Клиенты и сервер» приложение сначала подтверждало sudo в одном SSH-канале командой `sudo -S -v`, а затем запускало `wdtt-server admin` в другом канале через `sudo -n`. На серверах, где sudo-квитанция не передаётся между такими каналами, вторая команда завершалась ошибкой `sudo: a password is required`, хотя пароль sudo был указан правильно.

## Исправление

Проверка sudo и stdin-запрос к `wdtt-server admin` теперь выполняются в одном SSH-канале. Пароль передаётся первой строкой stdin в `sudo -S -p ''`, а `wdtt-server` получает оставшийся JSON-запрос из того же потока.

## Проверка

- Ошибка с двумя SSH-каналами воспроизведена на рабочем VPS.
- Одноканальный сценарий проверен: команда выполняется от root и получает данные из stdin.
- APK собран, обновление блока «Клиенты и сервер» успешно проверено на физическом Android-устройстве.